### PR TITLE
Add sobol as sampling method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.4"
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+Sobol = "ed01d8cd-4d21-5b2a-85b4-cc3bdc58bad4"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [weakdeps]
@@ -21,6 +22,7 @@ DoubleFloats = "1.4.3"
 Printf = "1.10"
 ProgressMeter = "1.10.4"
 Random = "1.10"
+Sobol = "1.5.0"
 Statistics = "1.10"
 Test = "1.10"
 TestItemRunner = "1.1"

--- a/docs/src/lib/internal.md
+++ b/docs/src/lib/internal.md
@@ -24,6 +24,7 @@ EpsilonBenchmarkResult
 ```@docs
 _grid_samples
 _random_samples
+_pseudo_random_samples
 make_bins
 ascii_hist
 print_hist_info

--- a/docs/src/literal/bench_epsilons.jl
+++ b/docs/src/literal/bench_epsilons.jl
@@ -10,7 +10,7 @@ foo(x, y) = sqrt(abs(x^2 - y^2))
 
 @bench_epsilons foo(1.0, y) ranges = begin
     y = (0.5, 1.0)
-end
+end search_method = :evenly_spaced
 
 # Function calls can be nested inside the expression as well, or multiple variables
 # sampled simultaneously:
@@ -27,6 +27,6 @@ z = 5.0
 @bench_epsilons foo(exp2(x), y * $z) ranges = begin
     x = (1.0, 2.0)
     y = (0.0, 0.3)
-end search_method = :random_search
+end search_method = :random
 
 # For information on the supported keyword arguments, see also [`@bench_epsilons`](@ref).

--- a/docs/src/literal/example.jl
+++ b/docs/src/literal/example.jl
@@ -45,14 +45,14 @@ significant_digits(p)
 @bench_epsilons f(x, y) ranges = begin
     x = (0.0, 5.0)
     y = (0.0, 5.0)
-end search_method = :random_search
+end
 
 # Compare this with the improved version:
 
 @bench_epsilons f_improved(x, y) ranges = begin
     x = (0.0, 5.0)
     y = (0.0, 5.0)
-end search_method = :random_search
+end
 
 # For more information on the [`@bench_epsilons`](@ref) macro, please refer to its docstring or the
 # [tutorial](bench_epsilons.md).

--- a/src/PrecisionCarriers.jl
+++ b/src/PrecisionCarriers.jl
@@ -3,6 +3,7 @@ module PrecisionCarriers
 using Statistics
 using Printf
 using ProgressMeter
+using Sobol
 
 export PrecisionCarrier
 export precify

--- a/src/bench/macros.jl
+++ b/src/bench/macros.jl
@@ -23,9 +23,10 @@ a terminal similar to BenchmarkTools' `@benchmark`.
 
 Supported keyword arguments:
 - `search_method`: How the sampling should be done. Supported are:
+    - `:pseudo_random`: Create pseudo-random sample points in the search space using Sobol.jl.
     - `:evenly_spaced`: Creates an evenly spaced grid across all ranges
-    - `:random_search`: Randomly samples points in the given ranges.
-    The default is `:evenly_spaced`.
+    - `:random`: Randomly samples points in the given ranges.
+    The default is `:pseudo_random`.
 - `samples`: The number of samples taken. Default: 10000
 - `epsilon_limit`: Results with epsilons larger than this will be stored together with the arguments
   that produced the imprecise result. Default: 1000
@@ -119,7 +120,7 @@ macro bench_epsilons(
 
     # call of the function and result handling, independent of the search method
     call_work = quote
-        next!(prog)
+        ProgressMeter.next!(prog)
         p = $(esc(func))($(func_args...))
         insert!(res, epsilons(p), $var_expr)
     end
@@ -136,10 +137,21 @@ macro bench_epsilons(
                 return res
             end
         end
-    elseif kwargs[:search_method] == :random_search
+    elseif kwargs[:search_method] == :random
         full_call = quote
             let # COV_EXCL_LINE
                 iter = PrecisionCarriers._random_samples(($(ranges)), $(kwargs[:samples]))
+                $call_setup # COV_EXCL_LINE
+                for $var_expr in iter
+                    $call_work # COV_EXCL_LINE
+                end
+                return res
+            end
+        end
+    elseif kwargs[:search_method] == :pseudo_random
+        full_call = quote
+            let # COV_EXCL_LINE
+                iter = PrecisionCarriers._pseudo_random_samples(($(ranges)), $(kwargs[:samples]))
                 $call_setup # COV_EXCL_LINE
                 for $var_expr in iter
                     $call_work # COV_EXCL_LINE

--- a/src/bench/utils.jl
+++ b/src/bench/utils.jl
@@ -41,6 +41,21 @@ function _random_samples(ranges::Tuple, n::Integer)
     return Iterators.map(f, 1:n)
 end
 
+"""
+    _pseudo_random_samples(ranges::Tuple{Vararg{Tuple{<:Real, <:Real}}}, n::Integer)
+
+Return an iterator generating `n` pseudo-randomly generated samples over the Cartesian grid defined by `ranges`.
+Each element of `ranges` must be a (lo, hi) tuple.
+This uses the package `Sobol.jl` to produce pseudorandom numbers within the given hypercube. The resulting
+numbers are more predictable and evenly spaced than real randomness, which can be better to sample a high dimensional
+space. Also, the generated samples are reproducible.
+"""
+function _pseudo_random_samples(ranges::Tuple, n::Integer)
+    @debug "generating pseudorandom samples from ranges: $ranges"
+    s = Sobol(getindex.(ranges, 1), getindex(ranges, 2))
+    return Iterators.take(s, n)
+end
+
 function _precify_args!(args, var_symbols)
     for i in eachindex(args)
         if typeof(args[i]) == Symbol


### PR DESCRIPTION
This adds pseudo-random sampling and also makes it the default search method for `@bench_epsilons`.
I also renamed `:random_search` to just `:random` since it's already the `search_method`. So I guess after this I will have to go to 0.2 next

Fixes #19